### PR TITLE
feat(bigquery): random mixing values

### DIFF
--- a/plugins/extractors/bigquery/README.md
+++ b/plugins/extractors/bigquery/README.md
@@ -49,6 +49,7 @@ source:
 | `max_page_size` | `int` | `100` | max page size hint used for fetching datasets/tables/rows from bigquery | *optional* |
 | `include_column_profile` | `bool` | `true` | true if you want to profile the column value such min, max, med, avg, top, and freq | *optional* |
 | `max_preview_rows` | `int` | `30` | max number of preview rows to fetch, `0` will skip preview fetching. Default to `30`. | *optional* |
+| `mix_values` | `bool` | `false` | true if you want to mix the column values with the preview rows. Default to `false`. | *optional* |
 | `collect_table_usage` | `boolean` | `false` | toggle feature to collect table usage, `true` will enable collecting table usage. Default to `false`. | *optional* |
 | `usage_period_in_day` | `int` | `7` | collecting log from `(now - usage_period_in_day)` until `now`. only matter if `collect_table_usage` is true. Default to `7`. | *optional* |
 | `usage_project_ids` | `[]string` | `[google-project-id, other-google-project-id]` | collecting log from defined GCP Project IDs. Default to BigQuery Project ID. | *optional* |

--- a/plugins/extractors/bigquery/bigquery_test.go
+++ b/plugins/extractors/bigquery/bigquery_test.go
@@ -5,6 +5,7 @@ package bigquery_test
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log"
 	"math/rand"
@@ -228,6 +229,13 @@ func TestExtract(t *testing.T) {
 			utils.AssertJSONFile(t, "testdata/expected-assets-mixed.json", actual, jsondiff.NoMatch)
 		})
 
+		t.Run("should not build preview rows when randomFn fails", func(t *testing.T) {
+			actual := runTest(t, cfg, func(max int64) (int64, error) {
+				return 0, errors.New("randomizer failed")
+			})
+			utils.AssertJSONFile(t, "testdata/expected-assets-no-preview.json", actual, jsondiff.FullMatch)
+		})
+
 		t.Run("should not randomize if rows < 2", func(t *testing.T) {
 			seed := int64(42)
 			randomizer := randFn(seed)
@@ -235,7 +243,7 @@ func TestExtract(t *testing.T) {
 			newCfg := cfg
 			newCfg.RawConfig["max_preview_rows"] = "1"
 
-			actual := runTest(t, cfg, randomizer)
+			actual := runTest(t, newCfg, randomizer)
 			utils.AssertJSONFile(t, "testdata/expected-assets.json", actual, jsondiff.FullMatch)
 		})
 	})

--- a/plugins/extractors/bigquery/bigquery_test.go
+++ b/plugins/extractors/bigquery/bigquery_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"math/rand"
 	"os"
 	"testing"
 	"time"
@@ -18,6 +19,7 @@ import (
 	"github.com/goto/meteor/test/mocks"
 	"github.com/goto/meteor/test/utils"
 	slog "github.com/goto/salt/log"
+	"github.com/nsf/jsondiff"
 	"github.com/ory/dockertest/v3"
 	"github.com/ory/dockertest/v3/docker"
 	"github.com/stretchr/testify/assert"
@@ -96,7 +98,7 @@ func mockClient(ctx context.Context, logger slog.Logger, config bigquery.Config)
 
 func TestInit(t *testing.T) {
 	t.Run("should return error if config is invalid", func(t *testing.T) {
-		extr := bigquery.New(utils.Logger, bigquery.CreateClient)
+		extr := bigquery.New(utils.Logger, bigquery.CreateClient, nil)
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 		err := extr.Init(ctx, plugins.Config{
@@ -109,7 +111,7 @@ func TestInit(t *testing.T) {
 		assert.ErrorAs(t, err, &plugins.InvalidConfigError{})
 	})
 	t.Run("should not return invalid config error if config is valid", func(t *testing.T) {
-		extr := bigquery.New(utils.Logger, bigquery.CreateClient)
+		extr := bigquery.New(utils.Logger, bigquery.CreateClient, nil)
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 		err := extr.Init(ctx, plugins.Config{
@@ -123,7 +125,7 @@ func TestInit(t *testing.T) {
 		assert.NotEqual(t, plugins.InvalidConfigError{}, err)
 	})
 	t.Run("should return error if service_account_base64 config is invalid", func(t *testing.T) {
-		extr := bigquery.New(utils.Logger, bigquery.CreateClient)
+		extr := bigquery.New(utils.Logger, bigquery.CreateClient, nil)
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 		err := extr.Init(ctx, plugins.Config{
@@ -138,7 +140,7 @@ func TestInit(t *testing.T) {
 	})
 
 	t.Run("should return no error", func(t *testing.T) {
-		extr := bigquery.New(utils.Logger, mockClient)
+		extr := bigquery.New(utils.Logger, mockClient, nil)
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 		err := extr.Init(ctx, plugins.Config{
@@ -153,11 +155,24 @@ func TestInit(t *testing.T) {
 }
 
 func TestExtract(t *testing.T) {
-	t.Run("should return no error", func(t *testing.T) {
-		extr := bigquery.New(utils.Logger, mockClient)
+	runTest := func(t *testing.T, cfg plugins.Config, randomizer func(int64) (int64, error)) []*v1beta2.Asset {
+		extr := bigquery.New(utils.Logger, mockClient, randomizer)
 		ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
 		defer cancel()
-		err := extr.Init(ctx, plugins.Config{
+		err := extr.Init(ctx, cfg)
+
+		assert.NoError(t, err)
+
+		emitter := mocks.NewEmitter()
+		err = extr.Extract(ctx, emitter.Push)
+		assert.NoError(t, err)
+
+		actual := getAllData(emitter, t)
+		return actual
+	}
+
+	t.Run("should return no error", func(t *testing.T) {
+		actual := runTest(t, plugins.Config{
 			URNScope: "test-bigquery",
 			RawConfig: map[string]interface{}{
 				"project_id":             projectID,
@@ -168,17 +183,61 @@ func TestExtract(t *testing.T) {
 					"tables":   []string{"dataset1.exclude_this_table"},
 				},
 			},
-		})
-
-		assert.NoError(t, err)
-
-		emitter := mocks.NewEmitter()
-		err = extr.Extract(ctx, emitter.Push)
-		assert.NoError(t, err)
-
-		actual := getAllData(emitter, t)
+		}, nil)
 
 		utils.AssertProtosWithJSONFile(t, "testdata/expected-assets.json", actual)
+	})
+
+	t.Run("with mix_values true", func(t *testing.T) {
+		cfg := plugins.Config{
+			URNScope: "test-bigquery",
+			RawConfig: map[string]interface{}{
+				"project_id":             projectID,
+				"max_preview_rows":       "5",
+				"mix_values":             "true",
+				"include_column_profile": "true",
+				"exclude": map[string]interface{}{
+					"datasets": []string{"exclude_this_dataset"},
+					"tables":   []string{"dataset1.exclude_this_table"},
+				},
+			},
+		}
+
+		randFn := func(seed int64) func(max int64) (int64, error) {
+			randomizer := rand.New(rand.NewSource(seed))
+
+			return func(max int64) (int64, error) {
+				return randomizer.Int63n(max), nil
+			}
+		}
+
+		t.Run("should return preview rows with mixed values", func(t *testing.T) {
+			seed := int64(42)
+			randomizer := randFn(seed)
+
+			actual := runTest(t, cfg, randomizer)
+
+			utils.AssertJSONFile(t, "testdata/expected-assets-mixed.json", actual, jsondiff.FullMatch)
+		})
+
+		t.Run("with different seed should not equal to expected", func(t *testing.T) {
+			seed := int64(99)
+			randomizer := randFn(seed)
+
+			actual := runTest(t, cfg, randomizer)
+			utils.AssertJSONFile(t, "testdata/expected-assets-mixed.json", actual, jsondiff.NoMatch)
+		})
+
+		t.Run("should not randomize if rows < 2", func(t *testing.T) {
+			seed := int64(42)
+			randomizer := randFn(seed)
+
+			newCfg := cfg
+			newCfg.RawConfig["max_preview_rows"] = "1"
+
+			actual := runTest(t, cfg, randomizer)
+			utils.AssertJSONFile(t, "testdata/expected-assets.json", actual, jsondiff.FullMatch)
+		})
 	})
 }
 

--- a/plugins/extractors/bigquery/testdata/data.yaml
+++ b/plugins/extractors/bigquery/testdata/data.yaml
@@ -42,6 +42,30 @@ projects:
               birthday: "2007-02-01"
               skillNum: 5
               created_at: '2022-01-02T18:00:00'
+            - id: 3
+              name: carol
+              structarr:
+                - key: profile
+                  value: '{"age": 20}'
+              birthday: "2002-03-01"
+              skillNum: 7
+              created_at: '2022-01-03T06:00:00'
+            - id: 4
+              name: dave
+              structarr:
+                - key: profile
+                  value: '{"age": 25}'
+              birthday: "1997-04-01"
+              skillNum: 9
+              created_at: '2022-01-04T00:00:00'
+            - id: 5
+              name: eve
+              structarr:
+                - key: profile
+                  value: '{"age": 30}'
+              birthday: "1992-05-01"
+              skillNum: 11
+              created_at: '2022-01-05T12:00:00'
         - id: exclude_this_table
           columns:
             - name: id

--- a/plugins/extractors/bigquery/testdata/expected-assets-mixed.json
+++ b/plugins/extractors/bigquery/testdata/expected-assets-mixed.json
@@ -1,0 +1,193 @@
+[
+    {
+        "create_time": null,
+        "data": {
+            "@type": "type.googleapis.com/gotocompany.assets.v1beta2.Table",
+            "attributes": {
+                "clustering_fields": [],
+                "dataset": "dataset1",
+                "full_qualified_name": "test-project-id:dataset1.table_a",
+                "partition_data": {
+                    "require_partition_filter": false
+                },
+                "project": "test-project-id",
+                "type": "TABLE"
+            },
+            "columns": [
+                {
+                    "attributes": {
+                        "mode": "REQUIRED"
+                    },
+                    "columns": [],
+                    "data_type": "INTEGER",
+                    "description": "",
+                    "is_nullable": false,
+                    "length": "0",
+                    "name": "id",
+                    "profile": {
+                        "avg": 0,
+                        "count": "0",
+                        "max": "",
+                        "med": 0,
+                        "min": "",
+                        "top": "",
+                        "unique": "0"
+                    }
+                },
+                {
+                    "attributes": {
+                        "mode": "REQUIRED"
+                    },
+                    "columns": [],
+                    "data_type": "STRING",
+                    "description": "",
+                    "is_nullable": false,
+                    "length": "0",
+                    "name": "name",
+                    "profile": {
+                        "avg": 0,
+                        "count": "0",
+                        "max": "",
+                        "med": 0,
+                        "min": "",
+                        "top": "",
+                        "unique": "0"
+                    }
+                },
+                {
+                    "attributes": {
+                        "mode": "REPEATED"
+                    },
+                    "columns": [
+                        {
+                            "attributes": {
+                                "mode": "NULLABLE"
+                            },
+                            "columns": [],
+                            "data_type": "STRING",
+                            "description": "",
+                            "is_nullable": true,
+                            "length": "0",
+                            "name": "key",
+                            "profile": null
+                        },
+                        {
+                            "attributes": {
+                                "mode": "NULLABLE"
+                            },
+                            "columns": [],
+                            "data_type": "JSON",
+                            "description": "",
+                            "is_nullable": true,
+                            "length": "0",
+                            "name": "value",
+                            "profile": null
+                        }
+                    ],
+                    "data_type": "RECORD",
+                    "description": "",
+                    "is_nullable": false,
+                    "length": "0",
+                    "name": "structarr",
+                    "profile": null
+                },
+                {
+                    "attributes": {
+                        "mode": "NULLABLE"
+                    },
+                    "columns": [],
+                    "data_type": "DATE",
+                    "description": "",
+                    "is_nullable": true,
+                    "length": "0",
+                    "name": "birthday",
+                    "profile": {
+                        "avg": 0,
+                        "count": "0",
+                        "max": "",
+                        "med": 0,
+                        "min": "",
+                        "top": "",
+                        "unique": "0"
+                    }
+                },
+                {
+                    "attributes": {
+                        "mode": "NULLABLE"
+                    },
+                    "columns": [],
+                    "data_type": "NUMERIC",
+                    "description": "",
+                    "is_nullable": true,
+                    "length": "0",
+                    "name": "skillNum",
+                    "profile": {
+                        "avg": 0,
+                        "count": "0",
+                        "max": "",
+                        "med": 0,
+                        "min": "",
+                        "top": "",
+                        "unique": "0"
+                    }
+                },
+                {
+                    "attributes": {
+                        "mode": "NULLABLE"
+                    },
+                    "columns": [],
+                    "data_type": "TIMESTAMP",
+                    "description": "",
+                    "is_nullable": true,
+                    "length": "0",
+                    "name": "created_at",
+                    "profile": {
+                        "avg": 0,
+                        "count": "0",
+                        "max": "",
+                        "med": 0,
+                        "min": "",
+                        "top": "",
+                        "unique": "0"
+                    }
+                }
+            ],
+            "create_time": "2023-06-13T03:46:12.372974Z",
+            "preview_fields": [
+                "id",
+                "name",
+                "structarr",
+                "birthday",
+                "skillNum",
+                "created_at"
+            ],
+            "preview_rows": [
+                [ 3, "dave", [ [ "profile", "{\"age\": 20}" ] ], "1997-04-01", "9", "2022-01-05T12:00:00Z" ],
+                [ 2, "eve", [ [ "profile", "{\"age\": 15}" ] ], "1992-05-01", "5", "2022-01-02T18:00:00Z" ],
+                [ 5, "alice", [ [ "profile", "{\"age\": 30}" ] ], "2002-03-01", "11", "2022-01-01T12:00:00Z" ],
+                [ 4, "bob", [ [ "profile", "{\"age\": 10}" ] ], "2007-02-01", "7", "2022-01-03T06:00:00Z" ],
+                [ 1, "carol", [ [ "profile", "{\"age\": 25}" ] ], "2012-01-01", "3", "2022-01-04T00:00:00Z" ]
+            ],
+            "profile": {
+                "common_joins": [],
+                "filters": [],
+                "partition_key": "",
+                "partition_value": "",
+                "total_rows": "0",
+                "usage_count": "0"
+            },
+            "update_time": "2023-06-13T03:46:12.372974Z"
+        },
+        "description": "",
+        "event": null,
+        "labels": {},
+        "lineage": null,
+        "name": "table_a",
+        "owners": [],
+        "service": "bigquery",
+        "type": "table",
+        "update_time": null,
+        "url": "",
+        "urn": "urn:bigquery:test-project-id:table:test-project-id:dataset1.table_a"
+    }
+]

--- a/plugins/extractors/bigquery/testdata/expected-assets-no-preview.json
+++ b/plugins/extractors/bigquery/testdata/expected-assets-no-preview.json
@@ -1,0 +1,180 @@
+[
+    {
+        "create_time": null,
+        "data": {
+            "@type": "type.googleapis.com/gotocompany.assets.v1beta2.Table",
+            "attributes": {
+                "clustering_fields": [],
+                "dataset": "dataset1",
+                "full_qualified_name": "test-project-id:dataset1.table_a",
+                "partition_data": {
+                    "require_partition_filter": false
+                },
+                "project": "test-project-id",
+                "type": "TABLE"
+            },
+            "columns": [
+                {
+                    "attributes": {
+                        "mode": "REQUIRED"
+                    },
+                    "columns": [],
+                    "data_type": "INTEGER",
+                    "description": "",
+                    "is_nullable": false,
+                    "length": "0",
+                    "name": "id",
+                    "profile": {
+                        "avg": 0,
+                        "count": "0",
+                        "max": "",
+                        "med": 0,
+                        "min": "",
+                        "top": "",
+                        "unique": "0"
+                    }
+                },
+                {
+                    "attributes": {
+                        "mode": "REQUIRED"
+                    },
+                    "columns": [],
+                    "data_type": "STRING",
+                    "description": "",
+                    "is_nullable": false,
+                    "length": "0",
+                    "name": "name",
+                    "profile": {
+                        "avg": 0,
+                        "count": "0",
+                        "max": "",
+                        "med": 0,
+                        "min": "",
+                        "top": "",
+                        "unique": "0"
+                    }
+                },
+                {
+                    "attributes": {
+                        "mode": "REPEATED"
+                    },
+                    "columns": [
+                        {
+                            "attributes": {
+                                "mode": "NULLABLE"
+                            },
+                            "columns": [],
+                            "data_type": "STRING",
+                            "description": "",
+                            "is_nullable": true,
+                            "length": "0",
+                            "name": "key",
+                            "profile": null
+                        },
+                        {
+                            "attributes": {
+                                "mode": "NULLABLE"
+                            },
+                            "columns": [],
+                            "data_type": "JSON",
+                            "description": "",
+                            "is_nullable": true,
+                            "length": "0",
+                            "name": "value",
+                            "profile": null
+                        }
+                    ],
+                    "data_type": "RECORD",
+                    "description": "",
+                    "is_nullable": false,
+                    "length": "0",
+                    "name": "structarr",
+                    "profile": null
+                },
+                {
+                    "attributes": {
+                        "mode": "NULLABLE"
+                    },
+                    "columns": [],
+                    "data_type": "DATE",
+                    "description": "",
+                    "is_nullable": true,
+                    "length": "0",
+                    "name": "birthday",
+                    "profile": {
+                        "avg": 0,
+                        "count": "0",
+                        "max": "",
+                        "med": 0,
+                        "min": "",
+                        "top": "",
+                        "unique": "0"
+                    }
+                },
+                {
+                    "attributes": {
+                        "mode": "NULLABLE"
+                    },
+                    "columns": [],
+                    "data_type": "NUMERIC",
+                    "description": "",
+                    "is_nullable": true,
+                    "length": "0",
+                    "name": "skillNum",
+                    "profile": {
+                        "avg": 0,
+                        "count": "0",
+                        "max": "",
+                        "med": 0,
+                        "min": "",
+                        "top": "",
+                        "unique": "0"
+                    }
+                },
+                {
+                    "attributes": {
+                        "mode": "NULLABLE"
+                    },
+                    "columns": [],
+                    "data_type": "TIMESTAMP",
+                    "description": "",
+                    "is_nullable": true,
+                    "length": "0",
+                    "name": "created_at",
+                    "profile": {
+                        "avg": 0,
+                        "count": "0",
+                        "max": "",
+                        "med": 0,
+                        "min": "",
+                        "top": "",
+                        "unique": "0"
+                    }
+                }
+            ],
+            "create_time": "2023-06-13T03:46:12.372974Z",
+            "preview_fields": [],
+            "preview_rows": null,
+            "profile": {
+                "common_joins": [],
+                "filters": [],
+                "partition_key": "",
+                "partition_value": "",
+                "total_rows": "0",
+                "usage_count": "0"
+            },
+            "update_time": "2023-06-13T03:46:12.372974Z"
+        },
+        "description": "",
+        "event": null,
+        "labels": {},
+        "lineage": null,
+        "name": "table_a",
+        "owners": [],
+        "service": "bigquery",
+        "type": "table",
+        "update_time": null,
+        "url": "",
+        "urn": "urn:bigquery:test-project-id:table:test-project-id:dataset1.table_a"
+    }
+]

--- a/test/utils/assert.go
+++ b/test/utils/assert.go
@@ -71,13 +71,25 @@ func AssertEqualProtos(t *testing.T, expected, actual interface{}) {
 func AssertProtosWithJSONFile(t *testing.T, expectedFilePath string, actual []*v1beta2.Asset) {
 	t.Helper()
 
+	AssertJSONFile(t, expectedFilePath, actual, jsondiff.FullMatch)
+}
+
+func AssertJSONFile(t *testing.T, expectedFilePath string, actual []*v1beta2.Asset, expectedDiff jsondiff.Difference) {
+	t.Helper()
+
 	expected, err := os.ReadFile(expectedFilePath)
 	require.NoError(t, err)
 
-	AssertJSONEq(t, expected, actual)
+	AssertJSON(t, expected, actual, expectedDiff)
 }
 
 func AssertJSONEq(t *testing.T, expected, actual interface{}) {
+	t.Helper()
+
+	AssertJSON(t, expected, actual, jsondiff.FullMatch)
+}
+
+func AssertJSON(t *testing.T, expected, actual interface{}, expectedDiff jsondiff.Difference) {
 	t.Helper()
 
 	asBytes := func(v interface{}) []byte {
@@ -101,10 +113,8 @@ func AssertJSONEq(t *testing.T, expected, actual interface{}) {
 	}
 
 	options := jsondiff.DefaultConsoleOptions()
-	diff, report := jsondiff.Compare(asBytes(expected), asBytes(actual), &options)
-	if diff != jsondiff.FullMatch {
-		t.Errorf("jsons do not match:\n %s", report)
-	}
+	actualDiff, report := jsondiff.Compare(asBytes(expected), asBytes(actual), &options)
+	assert.Equal(t, expectedDiff, actualDiff, "expected json is %s, got %s\n %s", expectedDiff, actualDiff, report)
 }
 
 func SortedAssets(assets []*v1beta2.Asset) []*v1beta2.Asset {


### PR DESCRIPTION
### Changes
- BigQuery: Add de-identification options by mixing the value from different rows. 
  Ensuring that the previewed value in a different column and the same row does not originate from the same individual