### PR TITLE
fix(cmd): version throw panic and not returning the version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -68,10 +68,10 @@ generate-proto: $(TOOLS_DIR)/buf ## regenerate protos
 	@echo " > protobuf compilation finished"
 
 build:
-	go build -ldflags "-X cmd.Version=${VERSION}" ${NAME}
+	go build -ldflags "-X ${NAME}/cmd.Version=${VERSION}" ${NAME}
 
 build-dev:
-	CGO_ENABLED=0 go build -ldflags "-X cmd.Version=dev" ${NAME}
+	CGO_ENABLED=0 go build -ldflags "-X ${NAME}/cmd.Version=dev" ${NAME}
 
 clean:
 	rm -rf dist/

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -30,7 +30,7 @@ func VersionCmd() *cobra.Command {
 			}
 
 			fmt.Println(Version)
-			fmt.Println(term.Yellow(version.UpdateNotice(Version, "gotocompany/meteor")))
+			fmt.Println(term.Yellow(version.UpdateNotice(Version, "goto/meteor")))
 
 			return nil
 		},


### PR DESCRIPTION
Running `meteor version` will result in panic due to wrong github repo (github.com/gotocompany). This PR will fix the wrong repo target to fetch the correct meteor version in correct repo (github.com/goto).