### PR TITLE
refactor: consistent err handling for OpenTelemetry

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -236,7 +236,7 @@ func (r *Agent) setupProcessor(ctx context.Context, pr recipe.PluginRecipe, str 
 		return fmt.Errorf("find processor %q: %w", pr.Name, err)
 	}
 
-	proc, err = otelmw.WithProcessorMW(proc, pr.Name, recipeName)
+	proc = otelmw.WithProcessor(pr.Name, recipeName)(proc)
 	if err != nil {
 		return fmt.Errorf("wrap processor %q: %w", pr.Name, err)
 	}
@@ -269,7 +269,7 @@ func (r *Agent) setupSink(ctx context.Context, sr recipe.PluginRecipe, stream *s
 		return fmt.Errorf("find sink %q: %w", sr.Name, err)
 	}
 
-	sink, err = otelmw.WithSinkMW(sink, sr.Name, recipeName)
+	sink = otelmw.WithSink(sr.Name, recipeName)(sink)
 	if err != nil {
 		return fmt.Errorf("wrap otel sink %q: %w", sr.Name, err)
 	}

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -88,14 +88,7 @@ func RunCmd() *cobra.Command {
 				}
 				defer doneOtlp()
 
-				mt, err := metrics.NewOtelMonitor()
-				if err != nil {
-					return err
-				}
-
-				if mt != nil {
-					mts = append(mts, mt)
-				}
+				mts = append(mts, metrics.NewOtelMonitor())
 			}
 
 			runner := agent.NewAgent(agent.Config{

--- a/metrics/opentelemetry_test.go
+++ b/metrics/opentelemetry_test.go
@@ -32,11 +32,10 @@ func TestOtelMonitor_RecordRun(t *testing.T) {
 		defer done()
 		assert.Nil(t, err)
 
-		monitor, err := metrics.NewOtelMonitor()
+		monitor := metrics.NewOtelMonitor()
 
 		monitor.RecordRun(ctx, agent.Run{Recipe: recipe, DurationInMs: duration, RecordCount: recordCount, Success: false})
 
-		assert.Nil(t, err)
 		assert.NotNil(t, monitor)
 		assert.NotNil(t, done)
 	})
@@ -62,7 +61,7 @@ func TestOtelMonitor_RecordPlugin(t *testing.T) {
 		defer done()
 		assert.Nil(t, err)
 
-		monitor, err := metrics.NewOtelMonitor()
+		monitor := metrics.NewOtelMonitor()
 
 		monitor.RecordPlugin(context.Background(),
 			agent.PluginInfo{
@@ -71,7 +70,6 @@ func TestOtelMonitor_RecordPlugin(t *testing.T) {
 				PluginType: "sink",
 				Success:    true,
 			})
-		assert.Nil(t, err)
 		assert.NotNil(t, monitor)
 		assert.NotNil(t, done)
 	})

--- a/metrics/otel_monitor.go
+++ b/metrics/otel_monitor.go
@@ -17,35 +17,27 @@ type OtelMonitor struct {
 	sinkRetries      metric.Int64Counter
 }
 
-func NewOtelMonitor() (*OtelMonitor, error) {
+func NewOtelMonitor() *OtelMonitor {
 	// init meters
-	meter := otel.Meter("")
+	meter := otel.Meter("github.com/goto/meteor/metrics")
 	recipeDuration, err := meter.Int64Histogram("meteor.recipe.duration", metric.WithUnit("ms"))
-	if err != nil {
-		return nil, err
-	}
+	handleOtelErr(err)
 
 	extractorRetries, err := meter.Int64Counter("meteor.extractor.retries")
-	if err != nil {
-		return nil, err
-	}
+	handleOtelErr(err)
 
 	assetsExtracted, err := meter.Int64Counter("meteor.assets.extracted")
-	if err != nil {
-		return nil, err
-	}
+	handleOtelErr(err)
 
 	sinkRetries, err := meter.Int64Counter("meteor.sink.retries")
-	if err != nil {
-		return nil, err
-	}
+	handleOtelErr(err)
 
 	return &OtelMonitor{
 		recipeDuration:   recipeDuration,
 		extractorRetries: extractorRetries,
 		assetsExtracted:  assetsExtracted,
 		sinkRetries:      sinkRetries,
-	}, nil
+	}
 }
 
 // RecordRun records a run behavior
@@ -88,4 +80,10 @@ func (m *OtelMonitor) RecordSinkRetryCount(ctx context.Context, pluginInfo agent
 			attribute.String("sink", pluginInfo.PluginName),
 			attribute.Int64("batch_size", int64(pluginInfo.BatchSize)),
 		))
+}
+
+func handleOtelErr(err error) {
+	if err != nil {
+		otel.Handle(err)
+	}
 }

--- a/plugins/extractors/bigtable/bigtable.go
+++ b/plugins/extractors/bigtable/bigtable.go
@@ -111,10 +111,7 @@ func (e *Extractor) Init(ctx context.Context, config plugins.Config) error {
 		return err
 	}
 
-	client, err = WithInstancesAdminClientMW(client, e.config.ProjectID)
-	if err != nil {
-		return err
-	}
+	client = WithInstanceAdminClientMW(e.config.ProjectID)(client)
 
 	e.instanceNames, err = instanceInfoGetter(ctx, client)
 	if err != nil {
@@ -150,10 +147,7 @@ func (e *Extractor) getTablesInfo(ctx context.Context, emit plugins.Emit) error 
 			return err
 		}
 
-		adminClient, err = WithAdminClientMW(adminClient, e.config.ProjectID, instance)
-		if err != nil {
-			return err
-		}
+		adminClient = WithAdminClientMW(e.config.ProjectID, instance)(adminClient)
 
 		tables, _ := adminClient.Tables(ctx)
 		var wg sync.WaitGroup

--- a/plugins/extractors/kafka/kafka.go
+++ b/plugins/extractors/kafka/kafka.go
@@ -92,10 +92,10 @@ func New(logger log.Logger) *Extractor {
 
 // Init initializes the extractor
 func (e *Extractor) Init(ctx context.Context, config plugins.Config) error {
-	clientDurn, err := otel.Meter("").
+	clientDurn, err := otel.Meter("github.com/goto/meteor/plugins/extractors/kafka").
 		Int64Histogram("meteor.kafka.client.duration", metric.WithUnit("ms"))
 	if err != nil {
-		return fmt.Errorf("create client duration histogram: %w", err)
+		otel.Handle(err)
 	}
 
 	e.clientDurn = clientDurn


### PR DESCRIPTION
- When counters or histograms are created with OpenTelemetry, if an error is returned, only log the error.
- Create the meter instance with the package name for creating counters and histograms.