### PR TITLE
fix: unhandled parse BQ table FQN

### DIFF
--- a/plugins/util.go
+++ b/plugins/util.go
@@ -145,5 +145,10 @@ func parseBQTableFQN(fqn string) (projectID, datasetID, tableID string, err erro
 	ss := strings.FieldsFunc(fqn, func(r rune) bool {
 		return r == ':' || r == '.'
 	})
+	if len(ss) < 3 {
+		return "", "", "", fmt.Errorf(
+			"unexpected BigQuery table FQN '%s', expected in format projectID:datasetID.tableID", fqn,
+		)
+	}
 	return ss[0], ss[1], ss[2], nil
 }

--- a/plugins/util_test.go
+++ b/plugins/util_test.go
@@ -41,6 +41,11 @@ func TestBigQueryTableFQNToURN(t *testing.T) {
 			fqn:         "bq-raw-internal:dagstream_production_feast09_s2id13_30min_demand",
 			expectedErr: "map URN: unexpected BigQuery table FQN 'bq-raw-internal:dagstream_production_feast09_s2id13_30min_demand', expected in format",
 		},
+		{
+			name:        "Invalid",
+			fqn:         ":.",
+			expectedErr: "map URN: unexpected BigQuery table FQN ':.', expected in format",
+		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {


### PR DESCRIPTION
### Context
Handle panic error due to invalid FQN (eg: `:.`)

```
agent run: close stream: panic: runtime error: index out of range [0] with length 0


goroutine 40 [running]:
runtime/debug.Stack()
        /opt/hostedtoolcache/go/1.21.3/x64/src/runtime/debug/stack.go:24 +0x5e
github.com/goto/meteor/agent.(*Agent).Run.func4.1()
        /home/runner/work/meteor/meteor/agent/agent.go:177 +0x7f
panic({0x2c0bf80?, 0xc008aaf7b8?})
        /opt/hostedtoolcache/go/1.21.3/x64/src/runtime/panic.go:914 +0x21f
github.com/goto/meteor/plugins.parseBQTableFQN({0xc0064f575b, 0x2})
        /home/runner/work/meteor/meteor/plugins/util.go:148 +0x154
github.com/goto/meteor/plugins.BigQueryTableFQNToURN({0xc0064f575b?, 0x0?})
        /home/runner/work/meteor/meteor/plugins/util.go:74 +0x18
github.com/goto/meteor/plugins/extractors/optimus.(*Extractor).buildDownstreams(0xc00112a390?, 0xc00112a390?)
        /home/runner/work/meteor/meteor/plugins/extractors/optimus/optimus.go:234 +0x8c
github.com/goto/meteor/plugins/extractors/optimus.(*Extractor).buildLineage(0x0?, 0x424a860?)
        /home/runner/work/meteor/meteor/plugins/extractors/optimus/optimus.go:201 +0x98
github.com/goto/meteor/plugins/extractors/optimus.(*Extractor).buildJob(0xc000c65340, {0x424a860, 0xc000ce2ac0}, 0xc002cee600, {0xc00037d190, 0xb}, {0xc0020b01b6, 0x9})
        /home/runner/work/meteor/meteor/plugins/extractors/optimus/optimus.go:140 +0x1a7
github.com/goto/meteor/plugins/extractors/optimus.(*Extractor).Extract(0xc000c65340, {0x424a860, 0xc000ce2ac0}, 0xc000da66f0)
        /home/runner/work/meteor/meteor/plugins/extractors/optimus/optimus.go:110 +0x699
github.com/goto/meteor/agent.(*Agent).setupExtractor.func1()
        /home/runner/work/meteor/meteor/agent/agent.go:226 +0xa4
github.com/goto/meteor/agent.(*Agent).Run.func4.3()
        /home/runner/work/meteor/meteor/agent/agent.go:195 +0x13
github.com/goto/meteor/agent.(*retrier).retry.func1()
        /home/runner/work/meteor/meteor/agent/retrier.go:38 +0x1b
github.com/cenkalti/backoff/v4.RetryNotifyWithTimer.Operation.withEmptyData.func1()
        /home/runner/go/pkg/mod/github.com/cenkalti/backoff/v4@v4.2.1/retry.go:18 +0x13
github.com/cenkalti/backoff/v4.doRetryNotify[...](0xc007e17e90?, {0x7fb5f0b29798, 0xc0009a0400}, 0xc007e17f88, {0x0, 0x0?})
        /home/runner/go/pkg/mod/github.com/cenkalti/backoff/v4@v4.2.1/retry.go:88 +0x13c
github.com/cenkalti/backoff/v4.RetryNotifyWithTimer(0xc000cd5bb4?, {0x7fb5f0b29798?, 0xc0009a0400?}, 0xc000f87eb8?, {0x0?, 0x0?})
        /home/runner/go/pkg/mod/github.com/cenkalti/backoff/v4@v4.2.1/retry.go:61 +0x5c
github.com/cenkalti/backoff/v4.RetryNotify(...)
        /home/runner/go/pkg/mod/github.com/cenkalti/backoff/v4@v4.2.1/retry.go:49
github.com/goto/meteor/agent.(*retrier).retry(0xc0014c3f60, {0x424a860, 0xc000ce2ac0}, 0xc000f87f78, 0xc000f87f80?)
        /home/runner/work/meteor/meteor/agent/retrier.go:37 +0x1a5
github.com/goto/meteor/agent.(*Agent).Run.func4()
        /home/runner/work/meteor/meteor/agent/agent.go:193 +0xe5
created by github.com/goto/meteor/agent.(*Agent).Run in goroutine 22
        /home/runner/work/meteor/meteor/agent/agent.go:173 +0x9eb
```