### PR TITLE
fix(run): return correct exit code on recipe failure

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -134,12 +134,15 @@ func RunCmd() *cobra.Command {
 			// Print the report
 			if failures > 0 {
 				fmt.Println("\nSome recipes were not successful")
+				err = fmt.Errorf("%d recipes failed", failures)
+				// Disable usage message on recipe failure
+				cmd.SilenceUsage = true
 			} else {
 				fmt.Println("\nAll recipes ran successful")
 			}
 			fmt.Printf("%d failing, %d successful, and %d total\n\n", failures, success, len(recipes))
 			printer.Table(os.Stdout, report)
-			return nil
+			return err
 		},
 	}
 


### PR DESCRIPTION
## Changes
-  [`cmd/run.go`](diffhunk://#diff-8146f8148ccbf6711d65f532f6ab9a7c8dfbdc3960c7ffc974f17d6d224dd349R137-R145) command now returns exit code 1 if any recipe fails, enabling proper error handling

Example output when some recipe fails
```
Some recipes were not successful
2 failing, 0 successful, and 2 total

Status  Recipe          Source  Duration(ms)    Records
✘       test-foo        csv     0 ms            0      
✘       test-bar        csv     0 ms            0      
2 recipes failed
exit status 1
➜  echo $?
1
```

Example output when the run successful
```
All recipes ran successful
0 failing, 1 successful, and 1 total

Status  Recipe          Source  Duration(ms)    Records
✓       test-foo        csv     196 ms        
➜  echo $?
0
```