### PR TITLE
Fix partition fields value on assets

### DIFF
--- a/plugins/extractors/maxcompute/maxcompute.go
+++ b/plugins/extractors/maxcompute/maxcompute.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"math/rand"
+	"regexp"
 	"time"
 
 	"github.com/aliyun/aliyun-odps-go-sdk/odps"
@@ -385,10 +386,16 @@ func (e *Extractor) buildTableAttributesData(schemaName, tableType string, table
 	}
 
 	var partitionNames []interface{}
-	if tableInfo.PartitionColumns != nil && len(tableInfo.PartitionColumns) > 0 {
-		partitionNames = make([]interface{}, len(tableInfo.PartitionColumns))
-		for i, column := range tableInfo.PartitionColumns {
-			partitionNames[i] = column.Name
+	if len(tableInfo.PartitionColumns) > 0 {
+		partitionNames = make([]interface{}, 0, len(tableInfo.PartitionColumns))
+		for _, column := range tableInfo.PartitionColumns {
+			name := column.Name
+			if column.GenerateExpression != nil {
+				if refCol := extractPartitionReferenceColumn(column.GenerateExpression); refCol != "" {
+					name = refCol
+				}
+			}
+			partitionNames = append(partitionNames, name)
 		}
 		attributesData[attributesDataPartitionFields] = partitionNames
 	}
@@ -502,6 +509,24 @@ func dataTypeToString(dataType datatype.DataType) string {
 		return dataType.Name()
 	}
 	return dataType.ID().String()
+}
+
+func extractPartitionReferenceColumn(expr interface{ String() string }) string {
+	if expr == nil {
+		return ""
+	}
+	raw := expr.String()
+	if raw == "" {
+		return ""
+	}
+
+	// TruncTime.String() in the SDK returns: trunc_time(`columnName`, 'datePart')
+	truncTimeRefRegex := regexp.MustCompile("(?i)trunc_time\\s*\\(\\s*`?([a-zA-Z_][a-zA-Z0-9_]*)`?")
+	if matches := truncTimeRefRegex.FindStringSubmatch(raw); len(matches) == 2 {
+		return matches[1]
+	}
+
+	return ""
 }
 
 func contains(slice []string, item string) bool {

--- a/plugins/extractors/maxcompute/maxcompute_test.go
+++ b/plugins/extractors/maxcompute/maxcompute_test.go
@@ -406,4 +406,43 @@ func TestExtract(t *testing.T) {
 		assert.NotEmpty(t, actual)
 		utils.AssertProtosWithJSONFile(t, "testdata/expected-assets-with-view-lineage.json", actual)
 	})
+
+	t.Run("should extract partition column name from generate expression", func(t *testing.T) {
+		autoPartitionTable := odps.NewTable(nil, projectID, "my_schema", "auto_partition_table")
+
+		autoPartitionSchemaBuilder := tableschema.NewSchemaBuilder()
+		autoPartitionSchemaBuilder.Name("auto_partition_table").Columns(c3, c4)
+		autoPartitionSchema := autoPartitionSchemaBuilder.Build()
+		autoPartitionSchema.TableName = "auto_partition_table"
+		autoPartitionSchema.CreateTime = common.GMTTime(newCreateTime)
+		autoPartitionSchema.LastModifiedTime = common.GMTTime(newCreateTime)
+		autoPartitionSchema.PartitionColumns = []tableschema.Column{
+			{
+				Name:               "_partition_value",
+				Type:               datatype.StringType,
+				GenerateExpression: tableschema.NewTruncTime("start_date", tableschema.DAY),
+			},
+		}
+
+		actual, err := runTest(t, plugins.Config{
+			URNScope: "test-maxcompute",
+			RawConfig: map[string]interface{}{
+				"project_name": projectID,
+				"access_key": map[string]interface{}{
+					"id":     "access_key_id",
+					"secret": "access_key_secret",
+				},
+				"endpoint_project": "https://example.com/some-api",
+			},
+		}, func(mockClient *mocks.MaxComputeClient) {
+			mockClient.EXPECT().ListSchema(mock.Anything).Return(schema1, nil)
+			mockClient.EXPECT().ListTable(mock.Anything, "my_schema").Return([]*odps.Table{autoPartitionTable}, nil)
+			mockClient.EXPECT().GetTableSchema(mock.Anything, autoPartitionTable).Return("MANAGED_TABLE", &autoPartitionSchema, nil)
+			mockClient.EXPECT().GetMaskingPolicies(mock.Anything).Return(map[string][]string{}, nil)
+		}, nil)
+
+		assert.Nil(t, err)
+		assert.NotEmpty(t, actual)
+		utils.AssertProtosWithJSONFile(t, "testdata/expected-assets-auto-partition.json", actual)
+	})
 }

--- a/plugins/extractors/maxcompute/testdata/expected-assets-auto-partition.json
+++ b/plugins/extractors/maxcompute/testdata/expected-assets-auto-partition.json
@@ -1,0 +1,64 @@
+[
+    {
+        "urn": "urn:maxcompute:test-project-id:table:test-project-id.my_schema.auto_partition_table",
+        "name": "auto_partition_table",
+        "service": "maxcompute",
+        "type": "table",
+        "url": "",
+        "description": "",
+        "data": {
+            "@type": "type.googleapis.com/gotocompany.assets.v1beta2.Table",
+            "profile": {
+                "common_joins": [],
+                "filters": [],
+                "partition_key": "",
+                "partition_value": "",
+                "total_rows": "0",
+                "usage_count": "0"
+            },
+            "columns": [
+                {
+                    "name": "user_id",
+                    "description": "Unique identifier for users",
+                    "data_type": "BIGINT",
+                    "is_nullable": false,
+                    "length": "0",
+                    "profile": null,
+                    "columns": [],
+                    "attributes": {}
+                },
+                {
+                    "name": "email",
+                    "description": "User email address",
+                    "data_type": "STRING",
+                    "is_nullable": false,
+                    "length": "0",
+                    "profile": null,
+                    "columns": [],
+                    "attributes": {}
+                }
+            ],
+            "preview_fields": [],
+            "preview_rows": null,
+            "ddl_statement": "create table if not exists test-project-id.`my_schema`.`auto_partition_table` (\n    `user_id` BIGINT not null comment 'Unique identifier for users',\n    `email` STRING not null comment 'User email address'\n)\nauto partitioned by (trunc_time(`start_date`, 'day') AS _partition_value);",
+            "attributes": {
+                "project_name": "test-project-id",
+                "resource_url": "/projects/test-project-id/schemas/my_schema/tables/auto_partition_table",
+                "schema": "my_schema",
+                "type": "MANAGED_TABLE",
+                "partition_fields": ["start_date"]
+            },
+            "create_time": "2024-11-18T08:00:00Z",
+            "update_time": "2024-11-18T08:00:00Z",
+            "labels": {}
+        },
+        "owners": [],
+        "lineage": null,
+        "is_deleted": false,
+        "labels": {},
+        "event": null,
+        "refreshed_at": null,
+        "create_time": "2024-11-18T08:00:00Z",
+        "update_time": "2024-11-18T08:00:00Z"
+    }
+]


### PR DESCRIPTION
Fetch partition_field value from the generateExpression field instead of name field. Since name field value will always be _partition_value.